### PR TITLE
商品詳細

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,7 +11,6 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
-    @user = User.all
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,11 @@ class ItemsController < ApplicationController
     @item = Item.new
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @user = User.all
+  end
+
   def create
     @item = Item.create(items_params)
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -121,7 +121,6 @@
   </div>
   <%# /FURIMAの特徴 %>
 
-
     <div class='item-contents'>
       <h2 class='title'>ピックアップカテゴリー</h2>
       <div class="subtitle" >
@@ -131,7 +130,7 @@
     <% if @items.present? %>
         <% @items.each do |item| %>
         <li class='list'>
-            <%= link_to items_path(item) do %>
+            <%= link_to item_path(item) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
             <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,11 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
+
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,14 +17,16 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.description %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.price %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+
+
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
@@ -33,40 +36,50 @@
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
+
+
+
+    <%# if user_signed_in? && current_user.id == tweet.user_id %>
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.item_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_days.name %></td>
         </tr>
       </tbody>
     </table>
+      <%# end %>
+
+
+
+
+
+
     <div class="option">
       <div class="favorite-btn">
         <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
@@ -79,6 +92,10 @@
     </div>
   </div>
   <%# /商品の概要 %>
+
+
+
+
 
   <div class="comment-box">
     <form>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,11 +10,16 @@
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
 
+
+
+    <%# if '商品が購入済みである' %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
+    <%# end %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -30,7 +35,6 @@
 
 
 
-
   <% if user_signed_in? && current_user.id == @item.user_id %>
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
@@ -40,6 +44,8 @@
   <% elsif user_signed_in? %> 
 
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+
+  <% end %>
     
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -72,11 +78,6 @@
         </tr>
       </tbody>
     </table>
-  <% end %>
-
-
-
-
 
     <div class="option">
       <div class="favorite-btn">
@@ -90,8 +91,6 @@
     </div>
   </div>
   
-
-
 
   <div class="comment-box">
     <form>
@@ -116,7 +115,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,7 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
+
+
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
@@ -24,24 +25,22 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
 
+
+
+
+
+  <% if user_signed_in? && current_user.id == @item.user_id %>
 
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+  <% elsif user_signed_in? %> 
+
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-
-
-
-    <%# if user_signed_in? && current_user.id == tweet.user_id %>
+    
     <div class="item-explain-box">
       <span><%= @item.description %></span>
     </div>
@@ -73,8 +72,7 @@
         </tr>
       </tbody>
     </table>
-      <%# end %>
-
+  <% end %>
 
 
 
@@ -91,9 +89,7 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
-
-
+  
 
 
 


### PR DESCRIPTION
# What
　商品詳細表示機能の実装

#Why
　・一つ一つの商品の詳細画面を表示できるようにして、詳しい商品詳細をユーザーが見られるようにするため
　・ログイン・商品出品者・ログインしていないユーザーによって画面を変えて、ユーザーが混乱しないようにするため

# Gyazo

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/90169e4e1e5f8b9b8470b8fa92a8136f

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/1ea02dd67b5b75ca813b91178728bc1f

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/c895a67de454e9488a566bc69bc033cc
